### PR TITLE
Add source repo references to plugin listings

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -32,8 +32,8 @@ The atuin-claude-ctrl-plugin (and future personal plugins) are installed via dir
 ## Decisions
 
 ### DEC-MARKET-001: Inline plugins, no submodules
-**Status:** accepted
-**Rationale:** The official marketplace uses inline copies. Claude Code's plugin system reads files directly from the marketplace clone — it does not perform `git submodule update`. The marketplace-relevant files (`.claude-plugin/`, `skills/`, `hooks/`) are copied into the marketplace repo. Tests and dev artifacts stay in the source repo.
+**Status:** superseded by DEC-MARKET-004
+**Rationale:** Originally used inline file copies. Superseded — plugin directories should reference source repos instead.
 
 ### DEC-MARKET-002: `plugins/` only, no `external_plugins/`
 **Status:** accepted
@@ -42,6 +42,10 @@ The atuin-claude-ctrl-plugin (and future personal plugins) are installed via dir
 ### DEC-MARKET-003: Plugin directory names match plugin.json `name` field
 **Status:** accepted
 **Rationale:** The install command resolves by directory name under `plugins/`. Directory name must match `name` in plugin.json for consistent UX (e.g., `atuin-history` → `/plugin install atuin-history@claude-code-market`).
+
+### DEC-MARKET-004: Plugin directories reference source repos, not static copies
+**Status:** accepted
+**Rationale:** Static file copies drift from the source repo and require manual syncing on every change. Each plugin directory in the marketplace should contain a `plugin.json` with a `homepage` field pointing to the source repo (e.g., `https://github.com/Mastermjr/atuin-claude-ctrl-plugin`), and a README that directs users to the source. The marketplace-relevant runtime files (hooks, skills) are kept in the marketplace for Claude Code's plugin loader, but the README and plugin.json make the source repo the canonical reference. Future: consider git submodules or a sync CI action to keep marketplace copies in sync with source repos automatically.
 
 ---
 
@@ -55,14 +59,14 @@ claude-code-market/
 └── plugins/
     └── atuin-history/
         ├── .claude-plugin/
-        │   └── plugin.json     # {name, description, author}
+        │   └── plugin.json     # {name, description, author, homepage → source repo}
         ├── hooks/
         │   ├── hooks.json      # Hook registration
         │   └── atuin-log.sh    # PostToolUse:Bash hook
         ├── skills/
         │   └── atuin/
         │       └── SKILL.md    # /atuin-history:atuin skill
-        └── README.md           # Plugin docs
+        └── README.md           # Points to source repo as canonical reference
 ```
 
 ---
@@ -70,29 +74,41 @@ claude-code-market/
 ## Phases
 
 ### Phase 1: Marketplace Structure + First Plugin (atuin-history)
-**Status:** in-progress
+**Status:** complete
 
-| Item | Description | Weight | Gate |
-|------|-------------|--------|------|
-| P1-1 | Create `plugins/atuin-history/` with `.claude-plugin/plugin.json`, hooks, skills, README | S | review |
-| P1-2 | Create marketplace `README.md` with overview and install instructions | S | review |
-| P1-3 | Add `.claude-plugin/plugin.json` to source repo (`atuin-claude-ctrl-plugin`) for parity | S | review |
+| Item | Description | Weight | Gate | Status |
+|------|-------------|--------|------|--------|
+| P1-1 | Create `plugins/atuin-history/` with `.claude-plugin/plugin.json`, hooks, skills, README | S | review | done |
+| P1-2 | Create marketplace `README.md` with overview and install instructions | S | review | done |
+| P1-3 | Add `.claude-plugin/plugin.json` to source repo (`atuin-claude-ctrl-plugin`) for parity | S | review | done (already existed) |
 
 ### Phase 2: Registration + E2E Test
-**Status:** pending
+**Status:** complete
+
+| Item | Description | Weight | Gate | Status |
+|------|-------------|--------|------|--------|
+| P2-1 | Register `claude-code-market` in `known_marketplaces.json` (user's machine) | S | none | done |
+| P2-2 | Test `/plugin install atuin-history@claude-code-market` end-to-end | S | review | done — all structure checks pass |
+
+### Phase 3: Source Repo References
+**Status:** in-progress
+
+Replace static file copies with proper source repo references per DEC-MARKET-004.
 
 | Item | Description | Weight | Gate |
 |------|-------------|--------|------|
-| P2-1 | Register `claude-code-market` in `known_marketplaces.json` (user's machine) | S | none |
-| P2-2 | Test `/plugin install atuin-history@claude-code-market` end-to-end | S | review |
+| P3-1 | Update `plugins/atuin-history/.claude-plugin/plugin.json` to include `homepage` field pointing to `https://github.com/Mastermjr/atuin-claude-ctrl-plugin` | S | review |
+| P3-2 | Update `plugins/atuin-history/README.md` to reference source repo as canonical, with link to issues/contributions | S | review |
+| P3-3 | Update marketplace `README.md` to include source repo link in the plugins table | S | review |
 
-### Phase 3: Future Plugins
+### Phase 4: Future Plugins
 **Status:** future
 
-Add more personal plugins as they are developed. Each gets a directory under `plugins/` with the standard `.claude-plugin/plugin.json` manifest.
+Add more personal plugins as they are developed. Each gets a directory under `plugins/` with the standard `.claude-plugin/plugin.json` manifest and `homepage` pointing to its source repo.
 
 ---
 
 ## Completed
 
-_(none yet)_
+- **Phase 1** — Marketplace structure established with atuin-history as first plugin (commit `e827641`)
+- **Phase 2** — Marketplace registered in `known_marketplaces.json`, all structure checks pass

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Register this marketplace so plugins are discoverable via `/plugin > Discover`:
 
 ## Available Plugins
 
-| Plugin | Description | Install |
-|--------|-------------|---------|
-| [atuin-history](plugins/atuin-history/) | Bridges Atuin shell history with Claude Code — logs commands and provides live search | `/plugin install atuin-history@claude-code-market` |
+| Plugin | Description | Source | Install |
+|--------|-------------|--------|---------|
+| [atuin-history](plugins/atuin-history/) | Bridges Atuin shell history with Claude Code — logs commands and provides live search | [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin) | `/plugin install atuin-history@claude-code-market` |
 
 ## Adding Plugins
 

--- a/plugins/atuin-history/.claude-plugin/plugin.json
+++ b/plugins/atuin-history/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "atuin-history",
   "description": "Bridges Atuin shell history with Claude Code — logs every Bash command Claude executes into Atuin and provides a skill for live history search, stats, and configuration",
+  "homepage": "https://github.com/Mastermjr/atuin-claude-ctrl-plugin",
   "author": {
     "name": "Mastermjr",
     "email": "mastermjr@users.noreply.github.com"

--- a/plugins/atuin-history/README.md
+++ b/plugins/atuin-history/README.md
@@ -2,7 +2,8 @@
 
 Bridges [Atuin](https://atuin.sh/) shell history with Claude Code.
 
-**Source repo:** [Mastermjr/atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin)
+> **Canonical source:** [Mastermjr/atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin)
+> Bug reports, feature requests, and contributions go to the source repo.
 
 ## What It Does
 
@@ -30,6 +31,12 @@ The hook fires automatically — no action needed. To use the skill:
 /atuin-history:atuin search for git commands from last week
 /atuin-history:atuin show me my stats
 ```
+
+## Source
+
+This marketplace listing contains the runtime files (hooks, skills) needed by Claude Code's plugin loader. The canonical source of truth — including tests, architecture docs, and full commit history — lives at:
+
+**https://github.com/Mastermjr/atuin-claude-ctrl-plugin**
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds `homepage` field to `plugin.json` pointing to [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin)
- Updates plugin README to mark the source repo as the canonical reference for bugs/contributions
- Adds Source column to the marketplace plugins table
- Marks Phase 1-2 complete in MASTER_PLAN.md, adds Phase 3 (DEC-MARKET-004)

## Test plan
- [ ] Verify `plugin.json` is valid JSON with `homepage` field
- [ ] Verify marketplace README renders source links correctly
- [ ] Verify `/plugin install atuin-history@claude-code-market` still works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)