### PR TITLE
Add GitHub Actions sync workflow for plugin sources

### DIFF
--- a/.github/workflows/sync-atuin-history.yml
+++ b/.github/workflows/sync-atuin-history.yml
@@ -1,0 +1,91 @@
+# @decision DEC-SYNC-001
+# @title GitHub Actions workflow syncs plugin files from source repos
+# @status accepted
+# @rationale Claude Code's plugin loader reads files directly from the marketplace
+#   clone — it does not follow git submodules or external references. Plugin source
+#   repos are the canonical home for development, but runtime files (hooks, skills,
+#   .claude-plugin/) must be inline in the marketplace. This workflow bridges the
+#   gap: when the source repo pushes changes, it triggers this workflow via
+#   repository_dispatch, which clones the source, copies runtime files, and opens
+#   a PR. The marketplace never drifts from the source for more than a few minutes.
+#
+#   To trigger manually: gh workflow run sync-atuin-history.yml
+#   To trigger from atuin repo: send a repository_dispatch event (see atuin repo README).
+
+name: Sync atuin-history plugin
+
+on:
+  # Triggered by the source repo via repository_dispatch
+  repository_dispatch:
+    types: [sync-atuin-history]
+
+  # Manual trigger for ad-hoc syncs
+  workflow_dispatch:
+
+  # Periodic fallback in case dispatch is missed
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout marketplace
+        uses: actions/checkout@v4
+
+      - name: Clone atuin source repo
+        run: |
+          git clone --depth 1 https://github.com/Mastermjr/atuin-claude-ctrl-plugin.git /tmp/atuin-src
+
+      - name: Sync runtime files
+        run: |
+          DEST="plugins/atuin-history"
+
+          # Sync .claude-plugin/
+          cp /tmp/atuin-src/.claude-plugin/plugin.json "$DEST/.claude-plugin/plugin.json"
+
+          # Sync hooks/
+          cp /tmp/atuin-src/hooks/hooks.json "$DEST/hooks/hooks.json"
+          cp /tmp/atuin-src/hooks/atuin-log.sh "$DEST/hooks/atuin-log.sh"
+          chmod +x "$DEST/hooks/atuin-log.sh"
+
+          # Sync skills/
+          cp /tmp/atuin-src/skills/atuin/SKILL.md "$DEST/skills/atuin/SKILL.md"
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "### Changed files:" >> "$GITHUB_STEP_SUMMARY"
+            git diff --name-only >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Get source commit SHA
+        if: steps.diff.outputs.changed == 'true'
+        id: source
+        run: |
+          SHA=$(git -C /tmp/atuin-src rev-parse --short HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: auto/sync-atuin-history
+          delete-branch: true
+          title: "sync: atuin-history from source (${{ steps.source.outputs.sha }})"
+          body: |
+            Automated sync from [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin) at commit `${{ steps.source.outputs.sha }}`.
+
+            **Files synced:** `.claude-plugin/plugin.json`, `hooks/`, `skills/`
+
+            This PR was created by the `sync-atuin-history` workflow. Review the diff and merge when ready.
+          commit-message: "sync: atuin-history plugin from source (${{ steps.source.outputs.sha }})"
+          labels: automated-sync

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -45,7 +45,11 @@ The atuin-claude-ctrl-plugin (and future personal plugins) are installed via dir
 
 ### DEC-MARKET-004: Plugin directories reference source repos, not static copies
 **Status:** accepted
-**Rationale:** Static file copies drift from the source repo and require manual syncing on every change. Each plugin directory in the marketplace should contain a `plugin.json` with a `homepage` field pointing to the source repo (e.g., `https://github.com/Mastermjr/atuin-claude-ctrl-plugin`), and a README that directs users to the source. The marketplace-relevant runtime files (hooks, skills) are kept in the marketplace for Claude Code's plugin loader, but the README and plugin.json make the source repo the canonical reference. Future: consider git submodules or a sync CI action to keep marketplace copies in sync with source repos automatically.
+**Rationale:** Static file copies drift from the source repo and require manual syncing on every change. Each plugin directory in the marketplace should contain a `plugin.json` with a `homepage` field pointing to the source repo (e.g., `https://github.com/Mastermjr/atuin-claude-ctrl-plugin`), and a README that directs users to the source. The marketplace-relevant runtime files (hooks, skills) are kept in the marketplace for Claude Code's plugin loader, but the README and plugin.json make the source repo the canonical reference.
+
+### DEC-MARKET-005: GitHub Actions workflow syncs runtime files from source repos
+**Status:** accepted
+**Rationale:** Claude Code's plugin loader does not follow git submodules or external references — runtime files must be inline. A GitHub Actions workflow bridges this gap: it clones the source repo, copies runtime files (`.claude-plugin/`, `hooks/`, `skills/`), and opens a PR. Triggers: `repository_dispatch` from source repo, manual `workflow_dispatch`, and weekly cron fallback. Plugin files in this marketplace should NEVER be edited directly — always edit in the source repo and let the sync propagate.
 
 ---
 
@@ -56,17 +60,20 @@ claude-code-market/
 ├── LICENSE              (MIT, exists)
 ├── README.md            (marketplace overview + install instructions)
 ├── MASTER_PLAN.md       (this file)
+├── .github/
+│   └── workflows/
+│       └── sync-atuin-history.yml  # Auto-syncs from source repo → marketplace
 └── plugins/
-    └── atuin-history/
+    └── atuin-history/              # ⚠️ DO NOT EDIT — auto-synced from source repo
         ├── .claude-plugin/
-        │   └── plugin.json     # {name, description, author, homepage → source repo}
+        │   └── plugin.json         # {name, description, author, homepage → source repo}
         ├── hooks/
-        │   ├── hooks.json      # Hook registration
-        │   └── atuin-log.sh    # PostToolUse:Bash hook
+        │   ├── hooks.json          # Hook registration
+        │   └── atuin-log.sh        # PostToolUse:Bash hook
         ├── skills/
         │   └── atuin/
-        │       └── SKILL.md    # /atuin-history:atuin skill
-        └── README.md           # Points to source repo as canonical reference
+        │       └── SKILL.md        # /atuin-history:atuin skill
+        └── README.md               # Points to source repo as canonical reference
 ```
 
 ---
@@ -90,21 +97,26 @@ claude-code-market/
 | P2-1 | Register `claude-code-market` in `known_marketplaces.json` (user's machine) | S | none | done |
 | P2-2 | Test `/plugin install atuin-history@claude-code-market` end-to-end | S | review | done — all structure checks pass |
 
-### Phase 3: Source Repo References
-**Status:** in-progress
+### Phase 3: Source Repo References + Auto-Sync
+**Status:** complete
 
-Replace static file copies with proper source repo references per DEC-MARKET-004.
+Replace static file copies with proper source repo references (DEC-MARKET-004) and GitHub Actions auto-sync (DEC-MARKET-005).
 
-| Item | Description | Weight | Gate |
-|------|-------------|--------|------|
-| P3-1 | Update `plugins/atuin-history/.claude-plugin/plugin.json` to include `homepage` field pointing to `https://github.com/Mastermjr/atuin-claude-ctrl-plugin` | S | review |
-| P3-2 | Update `plugins/atuin-history/README.md` to reference source repo as canonical, with link to issues/contributions | S | review |
-| P3-3 | Update marketplace `README.md` to include source repo link in the plugins table | S | review |
+| Item | Description | Weight | Gate | Status |
+|------|-------------|--------|------|--------|
+| P3-1 | Update `plugins/atuin-history/.claude-plugin/plugin.json` to include `homepage` field | S | review | done |
+| P3-2 | Update `plugins/atuin-history/README.md` to reference source repo as canonical | S | review | done |
+| P3-3 | Update marketplace `README.md` to include source repo link in the plugins table | S | review | done |
+| P3-4 | Create `.github/workflows/sync-atuin-history.yml` to auto-sync from source repo | S | review | done |
+| P3-5 | Document sync workflow in plugin README and marketplace README | S | review | done |
 
 ### Phase 4: Future Plugins
 **Status:** future
 
-Add more personal plugins as they are developed. Each gets a directory under `plugins/` with the standard `.claude-plugin/plugin.json` manifest and `homepage` pointing to its source repo.
+Add more personal plugins as they are developed. Each gets:
+- A directory under `plugins/` with the standard `.claude-plugin/plugin.json` manifest
+- A corresponding sync workflow in `.github/workflows/`
+- `homepage` in plugin.json pointing to its source repo
 
 ---
 
@@ -112,3 +124,4 @@ Add more personal plugins as they are developed. Each gets a directory under `pl
 
 - **Phase 1** — Marketplace structure established with atuin-history as first plugin (commit `e827641`)
 - **Phase 2** — Marketplace registered in `known_marketplaces.json`, all structure checks pass
+- **Phase 3** — Source repo references added, GitHub Actions sync workflow created (DEC-MARKET-005)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Register this marketplace so plugins are discoverable via `/plugin > Discover`:
 |--------|-------------|--------|---------|
 | [atuin-history](plugins/atuin-history/) | Bridges Atuin shell history with Claude Code — logs commands and provides live search | [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin) | `/plugin install atuin-history@claude-code-market` |
 
+## How It Works
+
+Plugin runtime files (hooks, skills, commands) must live inline in this repo because Claude Code's plugin loader reads directly from the marketplace clone. But each plugin is developed in its own source repo — **do not edit plugin files here directly.**
+
+A GitHub Actions workflow (`sync-atuin-history.yml`) automatically syncs runtime files from each plugin's source repo into this marketplace. When the source repo changes, the workflow opens a PR here. Merge it to publish the update.
+
+```
+Source repo (develop here)          Marketplace repo (install from here)
+atuin-claude-ctrl-plugin/    ──CI sync──▶   plugins/atuin-history/
+  hooks/                                      hooks/
+  skills/                                     skills/
+  .claude-plugin/                             .claude-plugin/
+```
+
 ## Adding Plugins
 
 Each plugin lives under `plugins/<name>/` with the standard structure:
@@ -23,13 +37,15 @@ Each plugin lives under `plugins/<name>/` with the standard structure:
 ```
 plugins/<name>/
 ├── .claude-plugin/
-│   └── plugin.json        # Required: {name, description, author}
+│   └── plugin.json        # Required: {name, description, author, homepage}
 ├── hooks/                 # Optional: hook definitions
 ├── skills/                # Optional: skill definitions
 ├── commands/              # Optional: slash commands
 ├── .mcp.json              # Optional: MCP server config
 └── README.md
 ```
+
+For each new plugin, create a corresponding sync workflow in `.github/workflows/` that copies runtime files from the source repo.
 
 ## License
 

--- a/plugins/atuin-history/README.md
+++ b/plugins/atuin-history/README.md
@@ -32,11 +32,29 @@ The hook fires automatically — no action needed. To use the skill:
 /atuin-history:atuin show me my stats
 ```
 
-## Source
+## Source & Sync
 
 This marketplace listing contains the runtime files (hooks, skills) needed by Claude Code's plugin loader. The canonical source of truth — including tests, architecture docs, and full commit history — lives at:
 
 **https://github.com/Mastermjr/atuin-claude-ctrl-plugin**
+
+### How sync works
+
+**DO NOT edit the plugin files in this marketplace repo directly.** They are auto-synced from the source repo by a GitHub Actions workflow (`sync-atuin-history.yml`).
+
+The sync triggers in three ways:
+1. **`repository_dispatch`** — the source repo sends a `sync-atuin-history` event after each push (set up a webhook or add a dispatch step to the source repo's CI)
+2. **Manual** — run `gh workflow run sync-atuin-history.yml` in this repo
+3. **Weekly fallback** — runs every Monday at 06:00 UTC as a safety net
+
+The workflow clones the source repo, copies runtime files (`.claude-plugin/`, `hooks/`, `skills/`) into `plugins/atuin-history/`, and opens a PR if anything changed. Merge the PR to update the marketplace.
+
+### To make changes to this plugin
+
+1. Edit files in [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin)
+2. Push to the source repo
+3. The sync workflow creates a PR here automatically
+4. Merge the PR
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-atuin-history.yml` — auto-syncs runtime files from [atuin-claude-ctrl-plugin](https://github.com/Mastermjr/atuin-claude-ctrl-plugin) into `plugins/atuin-history/`
- Updates plugin README with sync docs: how it works, how to trigger, and **do not edit plugin files here**
- Updates marketplace README with architecture diagram showing source→marketplace flow
- Updates MASTER_PLAN.md: Phase 3 complete, DEC-MARKET-005 added

## How the sync works
1. Source repo pushes changes → sends `repository_dispatch` event
2. Workflow clones source, copies `.claude-plugin/`, `hooks/`, `skills/`
3. Opens a PR if anything changed
4. Weekly cron fallback on Mondays at 06:00 UTC

## Why
Claude Code's plugin loader reads files from the marketplace clone directly — no submodules, no external references. But plugins should be developed in their own repos. This workflow bridges the gap.

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Trigger manually: `gh workflow run sync-atuin-history.yml --repo Mastermjr/claude-code-market`
- [ ] Confirm no PR created (files already in sync)
- [ ] Make a change in atuin source, trigger sync, confirm PR appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)