### PR TITLE
feat: setup skill — Mastermjr's Claude Code deployment blueprint

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "claude-code-market",
-  "version": "2.0.0",
-  "description": "Mastermjr's personal plugin marketplace — includes plugin-dev skill",
+  "version": "2.1.0",
+  "description": "Mastermjr's personal plugin marketplace — includes plugin-dev skill and Claude Code setup hub",
   "author": {"name": "Mastermjr"},
   "homepage": "https://github.com/Mastermjr/claude-code-market",
-  "skills": ["skills/plugin-dev"],
+  "skills": ["skills/plugin-dev", "skills/setup"],
   "strict": true
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ Or with a specific question:
 /claude-code-market:plugin-dev How do I add a PostToolUse hook to my plugin?
 ```
 
+## Recommended Setup
+
+This marketplace is part of a broader Claude Code configuration. For the full Mastermjr setup — including companion marketplaces and recommended plugins — use the guided setup skill:
+
+```
+/claude-code-market:setup
+```
+
+Or follow the quick-start sequence manually:
+
+```
+# Register companion marketplace
+/plugin marketplace add Mastermjr/claude-code-market
+/plugin marketplace add astral-sh/claude-code-plugins
+
+# Install recommended plugins
+/plugin install atuin-history@claude-code-market
+/plugin install frontend-design@claude-plugins-official
+/plugin install context7@claude-plugins-official
+/plugin install astral@astral-sh
+```
+
+**Companion marketplace:** [astral-sh/claude-code-plugins](https://github.com/astral-sh/claude-code-plugins) — Astral's official Claude Code plugins providing uv, ty, ruff, and the ty LSP server.
+
 ## How It Works
 
 ```

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: setup
+description: Mastermjr's personal Claude Code deployment blueprint. Sets up all recommended marketplaces, plugins, and configuration. Use when setting up a new machine or reconfiguring Claude Code.
+context: fork
+agent: general-purpose
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+<!--
+@decision DEC-MARKET-009
+@title Marketplace as setup hub — recommends companion marketplaces via setup skill
+@status accepted
+@rationale The marketplace evolves from a passive plugin listing into an active "setup hub"
+  for Claude Code. A /claude-code-market:setup skill guides users through registering
+  recommended companion marketplaces and installing recommended plugins. The approach is
+  guide-based (presents recommendations and commands) rather than automated config mutation —
+  respecting user agency while reducing discovery friction.
+-->
+
+# Mastermjr's Claude Code Setup Blueprint
+
+This skill walks you through setting up Claude Code exactly the way Mastermjr runs it — preferred marketplaces, plugins, model, and settings.
+
+This is a **personal blueprint**, not a generic getting-started guide. Every recommendation here is deliberate.
+
+---
+
+## Step 1: Check What's Already Installed
+
+Before installing anything, let's see your current state. Run these commands in Claude Code:
+
+```
+/plugin list-marketplaces
+/plugin list
+```
+
+Note which marketplaces and plugins you already have. We'll only install what's missing.
+
+---
+
+## Step 2: Register Marketplaces
+
+**`claude-plugins-official`** is built in — no registration needed.
+
+Register these two companion marketplaces:
+
+```
+/plugin marketplace add Mastermjr/claude-code-market
+/plugin marketplace add astral-sh/claude-code-plugins
+```
+
+| Marketplace | What It Provides |
+|-------------|-----------------|
+| `Mastermjr/claude-code-market` | Personal plugins: Atuin history integration, plugin-dev reference skill, this setup skill |
+| `astral-sh/claude-code-plugins` | Astral's official Python tooling plugins: uv, ty, ruff + ty LSP |
+
+---
+
+## Step 3: Install Plugins
+
+Install all recommended plugins. Skip any you don't need.
+
+### Shell & History
+
+```
+/plugin install atuin-history@claude-code-market
+```
+
+**atuin-history** — Bridges Atuin shell history with Claude Code. Logs commands Claude executes and lets you search your shell history directly from Claude Code.
+
+**Prerequisite:** Atuin v18+ must be installed. Check with `atuin --version`. Install from [atuin.sh](https://atuin.sh) if missing.
+
+### Frontend Development
+
+```
+/plugin install frontend-design@claude-plugins-official
+```
+
+**frontend-design** — UI/UX implementation guidance. Helps Claude make better decisions about layouts, component design, and visual hierarchy.
+
+### Documentation
+
+```
+/plugin install context7@claude-plugins-official
+```
+
+**context7** — Real-time documentation lookup via Upstash Context7 MCP. Gives Claude access to current library docs instead of relying on training data.
+
+**Prerequisite:** Node.js must be installed (for the MCP server). Check with `node --version`.
+
+### Python Tooling
+
+```
+/plugin install astral@astral-sh
+```
+
+**astral** — The full Astral Python toolchain: uv package manager, ruff linter/formatter, ty type checker, and ty LSP server integration.
+
+**Prerequisite:** `uvx` must be available (comes with uv). Install uv from [docs.astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/).
+
+### Plugin Development
+
+```
+/plugin install claude-code-market@claude-code-market
+```
+
+**claude-code-market** — Installs this marketplace as a plugin, providing the `plugin-dev` skill: a comprehensive reference for designing, building, and distributing Claude Code plugins.
+
+---
+
+## Quick-Start: Full Setup Sequence
+
+If you're setting up from scratch, run these in order:
+
+```bash
+# Register marketplaces
+/plugin marketplace add Mastermjr/claude-code-market
+/plugin marketplace add astral-sh/claude-code-plugins
+
+# Install plugins
+/plugin install atuin-history@claude-code-market
+/plugin install frontend-design@claude-plugins-official
+/plugin install context7@claude-plugins-official
+/plugin install astral@astral-sh
+```
+
+---
+
+## Step 4: Recommended Settings
+
+Add these to your `settings.local.json` (user-level settings, not committed to repos):
+
+```json
+{
+  "model": "opus",
+  "enableAllProjectMcpServers": true
+}
+```
+
+`settings.local.json` lives at `~/.claude/settings.local.json`.
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `model` | `"opus"` | Best reasoning for complex tasks. Claude Code defaults to a lighter model — override here. |
+| `enableAllProjectMcpServers` | `true` | Automatically enables MCP servers declared in `.mcp.json` without prompting per-project. Required for context7 to work seamlessly. |
+
+---
+
+## Prerequisites Summary
+
+| Prerequisite | Required By | Check | Install |
+|-------------|-------------|-------|---------|
+| Atuin v18+ | `atuin-history` | `atuin --version` | [atuin.sh](https://atuin.sh) |
+| Node.js | `context7` | `node --version` | [nodejs.org](https://nodejs.org) |
+| uvx (via uv) | `astral` ty LSP | `uvx --version` | [docs.astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/) |
+
+---
+
+## Walkthrough Mode
+
+If you'd like me to guide you interactively:
+
+1. Tell me which step you're on
+2. I'll check what's installed, identify what's missing, and walk through each installation
+3. I can verify each plugin loaded correctly before moving to the next
+
+Just say "let's go" and I'll start by checking your current setup.

--- a/tests/validate-wave3.sh
+++ b/tests/validate-wave3.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Validates Wave 3 additions: setup skill, README recommended section, plugin.json update
+set -euo pipefail
+
+ERRORS=0
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --- W3-1: Setup skill ---
+echo "=== W3-1: Setup Skill ==="
+
+echo "Checking skills/setup/SKILL.md exists..."
+[ -f "$REPO_ROOT/skills/setup/SKILL.md" ] || { echo "FAIL: skills/setup/SKILL.md missing"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md has YAML frontmatter..."
+head -1 "$REPO_ROOT/skills/setup/SKILL.md" | grep -q "^---" || { echo "FAIL: SKILL.md missing frontmatter"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md declares name: setup..."
+grep -q "^name: setup" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: name: setup not found in frontmatter"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md declares context: fork..."
+grep -q "^context: fork" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: context: fork not found in frontmatter"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md includes marketplace add commands..."
+grep -q "marketplace add Mastermjr/claude-code-market" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: Mastermjr marketplace command missing"; ERRORS=$((ERRORS+1)); }
+grep -q "marketplace add astral-sh/claude-code-plugins" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: astral-sh marketplace command missing"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md includes all recommended plugin install commands..."
+grep -q "atuin-history@claude-code-market" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: atuin-history install command missing"; ERRORS=$((ERRORS+1)); }
+grep -q "frontend-design@claude-plugins-official" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: frontend-design install command missing"; ERRORS=$((ERRORS+1)); }
+grep -q "context7@claude-plugins-official" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: context7 install command missing"; ERRORS=$((ERRORS+1)); }
+grep -q "astral@astral-sh" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: astral install command missing"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md includes recommended settings..."
+grep -q '"model"' "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: model setting missing"; ERRORS=$((ERRORS+1)); }
+grep -q '"enableAllProjectMcpServers"' "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: enableAllProjectMcpServers setting missing"; ERRORS=$((ERRORS+1)); }
+grep -q '"opus"' "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: opus model value missing"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md includes prerequisites..."
+grep -q "Atuin" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: Atuin prerequisite missing"; ERRORS=$((ERRORS+1)); }
+grep -q "Node.js" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: Node.js prerequisite missing"; ERRORS=$((ERRORS+1)); }
+grep -q "uvx" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: uvx prerequisite missing"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking SKILL.md has @decision DEC-MARKET-009 annotation..."
+grep -q "DEC-MARKET-009" "$REPO_ROOT/skills/setup/SKILL.md" || { echo "FAIL: @decision DEC-MARKET-009 missing"; ERRORS=$((ERRORS+1)); }
+
+# --- W3-2: README ---
+echo ""
+echo "=== W3-2: README Recommended Setup Section ==="
+
+echo "Checking README has Recommended Setup section..."
+grep -q "## Recommended Setup" "$REPO_ROOT/README.md" || { echo "FAIL: 'Recommended Setup' section missing from README"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking README references setup skill..."
+grep -q "claude-code-market:setup" "$REPO_ROOT/README.md" || { echo "FAIL: setup skill reference missing from README"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking README references astral-sh marketplace..."
+grep -q "astral-sh/claude-code-plugins" "$REPO_ROOT/README.md" || { echo "FAIL: astral-sh marketplace reference missing from README"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking README Recommended Setup appears before How It Works..."
+python3 -c "
+content = open('$REPO_ROOT/README.md').read()
+pos_setup = content.find('## Recommended Setup')
+pos_how = content.find('## How It Works')
+if pos_setup == -1:
+    print('FAIL: Recommended Setup not found')
+    exit(1)
+if pos_how == -1:
+    print('FAIL: How It Works not found')
+    exit(1)
+if pos_setup >= pos_how:
+    print('FAIL: Recommended Setup must appear before How It Works')
+    exit(1)
+print('  OK: Recommended Setup appears before How It Works')
+" || ERRORS=$((ERRORS+1))
+
+# --- W3-3: plugin.json ---
+echo ""
+echo "=== W3-3: plugin.json Update ==="
+
+echo "Checking plugin.json is valid JSON..."
+python3 -m json.tool "$REPO_ROOT/.claude-plugin/plugin.json" > /dev/null || { echo "FAIL: invalid JSON"; ERRORS=$((ERRORS+1)); }
+
+echo "Checking plugin.json includes skills/setup..."
+python3 -c "
+import json
+p = json.load(open('$REPO_ROOT/.claude-plugin/plugin.json'))
+skills = p.get('skills', [])
+if 'skills/setup' not in skills:
+    print('FAIL: skills/setup not in skills array')
+    exit(1)
+print(f'  OK: skills array = {skills}')
+" || ERRORS=$((ERRORS+1))
+
+echo "Checking plugin.json version is 2.1.0..."
+python3 -c "
+import json
+p = json.load(open('$REPO_ROOT/.claude-plugin/plugin.json'))
+v = p.get('version', '')
+if v != '2.1.0':
+    print(f'FAIL: version is {v!r}, expected 2.1.0')
+    exit(1)
+print(f'  OK: version = {v}')
+" || ERRORS=$((ERRORS+1))
+
+echo "Checking plugin.json still includes skills/plugin-dev..."
+python3 -c "
+import json
+p = json.load(open('$REPO_ROOT/.claude-plugin/plugin.json'))
+skills = p.get('skills', [])
+if 'skills/plugin-dev' not in skills:
+    print('FAIL: skills/plugin-dev missing from skills array')
+    exit(1)
+print('  OK: skills/plugin-dev still present')
+" || ERRORS=$((ERRORS+1))
+
+# --- Summary ---
+echo ""
+if [ $ERRORS -eq 0 ]; then
+  echo "ALL WAVE 3 CHECKS PASSED"
+else
+  echo "FAILED: $ERRORS error(s)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `/claude-code-market:setup` skill — personal deployment blueprint with all recommended marketplaces, plugins, settings, and prerequisites
- Add "Recommended Setup" section to README
- Bump plugin version to 2.1.0, register setup skill

Closes #12, closes #13, closes #14

## What the setup skill includes
- 2 companion marketplaces (claude-code-market, astral-sh)
- 5 plugins by category (shell, frontend, docs, python, plugin-dev)
- Recommended settings.local.json
- Prerequisites table (Atuin, Node.js, uvx)
- Walkthrough mode for interactive setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)